### PR TITLE
change default BC for 2D Simulation

### DIFF
--- a/geoscilabs/dcip/DCWidgetPlate2_5D.py
+++ b/geoscilabs/dcip/DCWidgetPlate2_5D.py
@@ -88,10 +88,10 @@ def plate_fields(A, B, dx, dz, xc, zc, rotAng, sigplate, sighalf):
             src = DC.sources.Dipole([], np.r_[A, 0.0], np.r_[B, 0.0])
         survey = DC.survey.Survey([src])
         problem = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type='Dirichlet'
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
         problem_prim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type='Dirichlet'
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
 
         total_field = problem.fields(mtrue)

--- a/geoscilabs/dcip/DCWidgetResLayer2_5D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2_5D.py
@@ -99,11 +99,11 @@ def model_fields(A, B, zcLayer, dzLayer, xc, zc, r, sigLayer, sigTarget, sigHalf
             src = DC.sources.Dipole([], np.r_[A, 0.0], np.r_[B, 0.0])
         survey = DC.Survey([src])
         sim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type="Dirichlet"
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
         total_field = sim.fields(mtrue)
         sim_prim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type="Dirichlet"
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
         primary_field = sim_prim.fields(mhalf)
 

--- a/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
+++ b/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
@@ -165,13 +165,13 @@ def model_fields(A, B, mtrue, mhalf, mair, mover, whichprimary="air"):
             src = DC.sources.Dipole([], np.r_[A, surfaceA], np.r_[B, surfaceB])
         survey = DC.survey.Survey([src])
         problem = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type="Dirichlet"
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
         problem_prim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type="Dirichlet"
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
         problem_air = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso, bc_type="Dirichlet"
+            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
         )
 
         if whichprimary == "air":

--- a/geoscilabs/dcip/DC_cylinder.py
+++ b/geoscilabs/dcip/DC_cylinder.py
@@ -88,10 +88,10 @@ def cylinder_fields(A, B, r, sigcyl, sighalf, xc=0.0, zc=-20.0):
 
         # make two simulations for the seperate field objects
         sim_primary = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso, bc_type='Dirichlet'
+            mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso
         )
         sim_total = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso, bc_type='Dirichlet'
+            mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso
         )
 
         primary_field = sim_primary.fields(mhalf)


### PR DESCRIPTION
Dirichlet BC implied zero dirichlet everywhere, Now we just default to simpeg's prefered method (This case a `Robin` boundary condition at the sides and zero `Neumann` at the top.