### PR TITLE
Pin SimPEG to v0.19.0 in environment_dev.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7, "3.10"]
+        python-version: ["3.8", "3.10"]
         test-file: ["tests/test_dcip.py", "tests/test_em.py", "tests/test_gpr.py tests/test_seismic.py", "tests/test_inversion.py", "tests/test_gravity.py tests/test_mag.py"]
 
     steps:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pip
   - pymatsolver
   - requests
-  - SimPEG
+  - SimPEG==0.19.0
   - pytest
   - flake8
   - black


### PR DESCRIPTION
Pin SimPEG version to v0.19.0 in the `environment_dev.yml` file, so
tests in GitHub Actions are run using the same version of SimPEG that
the gpgLabs are using. Replace Python 3.7 to Python 3.8 in Actions.

These changes are related to the ones made in
https://github.com/geoscixyz/gpgLabs/pull/136
