### PR TITLE
replace gridLoc with grid_loc for the dcip 2.5D app

### DIFF
--- a/geoscilabs/dcip/DCWidgetResLayer2_5D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2_5D.py
@@ -264,7 +264,7 @@ def get_Surface_Potentials(survey, src, field_obj):
     phiScale = 0.0
 
     if survey == "Pole-Dipole" or survey == "Pole-Pole":
-        refInd = utils.closestPoints(mesh, [xmax + 60.0, 0.0], gridLoc="CC")
+        refInd = utils.closestPoints(mesh, [xmax + 60.0, 0.0], grid_loc="CC")
         # refPoint =  CCLoc[refInd]
         # refSurfaceInd = np.where(xSurface == refPoint[0])
         # phiScale = np.median(phiSurface)


### PR DESCRIPTION
Fix error for `gridLoc` when using the pole-pole setup for the 2.5D app