### PR TITLE
Replace deprecated methods in discretize for new ones

### DIFF
--- a/geoscilabs/dcip/DCLayers.py
+++ b/geoscilabs/dcip/DCLayers.py
@@ -305,7 +305,7 @@ def plot_layer_potentials(rho1, rho2, h, A, B, M, N, imgplt="Model"):
     #     clabel = 'Potential (V)'
 
     elif imgplt == "Potential":
-        Pc = mesh.getInterpolationMat(pltgrid, "CC")
+        Pc = mesh.get_interpolation_matrix(pltgrid, "CC")
 
         V = solve_2D_potentials(rho1, rho2, h, np.r_[A, 0.0, 0.0], np.r_[B, 0.0, 0.0])
 
@@ -341,7 +341,7 @@ def plot_layer_potentials(rho1, rho2, h, A, B, M, N, imgplt="Model"):
 
     elif imgplt == "E":
 
-        Pc = mesh.getInterpolationMat(pltgrid, "CC")
+        Pc = mesh.get_interpolation_matrix(pltgrid, "CC")
 
         ex, ez, V = solve_2D_E(rho1, rho2, h, np.r_[A, 0.0, 0.0], np.r_[B, 0.0, 0.0])
 
@@ -388,7 +388,7 @@ def plot_layer_potentials(rho1, rho2, h, A, B, M, N, imgplt="Model"):
 
     elif imgplt == "J":
 
-        Pc = mesh.getInterpolationMat(pltgrid, "CC")
+        Pc = mesh.get_interpolation_matrix(pltgrid, "CC")
 
         Jx, Jz, V = solve_2D_J(rho1, rho2, h, np.r_[A, 0.0, 0.0], np.r_[B, 0.0, 0.0])
 

--- a/geoscilabs/dcip/DCLayers.py
+++ b/geoscilabs/dcip/DCLayers.py
@@ -162,15 +162,15 @@ def solve_2D_potentials(rho1, rho2, h, A, B):
     a = utils.closestPoints(mesh, A[:2])
     b = utils.closestPoints(mesh, B[:2])
 
-    q[a] = 1.0 / mesh.vol[a]
-    q[b] = -1.0 / mesh.vol[b]
+    q[a] = 1.0 / mesh.cell_volumes[a]
+    q[b] = -1.0 / mesh.cell_volumes[b]
 
-    # q = q * 1./mesh.vol
+    # q = q * 1./mesh.cell_volumes
 
     A = (
-        mesh.cellGrad.T
+        mesh.cell_gradient.T
         * utils.sdiag(1.0 / (mesh.dim * mesh.aveF2CC.T * (1.0 / sigma)))
-        * mesh.cellGrad
+        * mesh.cell_gradient
     )
     Ainv = Pardiso(A)
 
@@ -184,7 +184,7 @@ def solve_2D_E(rho1, rho2, h, A, B):
     """
 
     V = solve_2D_potentials(rho1, rho2, h, A, B)
-    E = -mesh.cellGrad * V
+    E = -mesh.cell_gradient * V
     E = mesh.aveF2CCV * E
     ex = E[: mesh.nC]
     ez = E[mesh.nC :]


### PR DESCRIPTION
Replace the deprecated `TensorMesh.getInterpolationMat` method for `TensorMesh.get_interpolation_matrix`. Replace deprecated properties `vol` and `cellGrad` for `cell_volumes` and `cell_gradient`, respectively.

The usage of the deprecated methods leads to an error when trying to plot the potential, E and J fields.