### PR TITLE
Plot unbroken field lines in DCIP widgets

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - discretize
   - ipywidgets>=0.6.0
   - jupyter
-  - matplotlib<3.5
+  - matplotlib==3.6.*
   - Pillow
   - pip
   - pymatsolver

--- a/geoscilabs/dcip/DCWidgetPlate2_5D.py
+++ b/geoscilabs/dcip/DCWidgetPlate2_5D.py
@@ -527,7 +527,7 @@ def PLOT(
         label = "Electric Field (V/m)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)

--- a/geoscilabs/dcip/DCWidgetPlate_2D.py
+++ b/geoscilabs/dcip/DCWidgetPlate_2D.py
@@ -528,7 +528,7 @@ def plot_Surface_Potentials(
         label = "Electric Field (V/m)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)
@@ -553,7 +553,7 @@ def plot_Surface_Potentials(
         label = "Current density ($A/m^2$)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)

--- a/geoscilabs/dcip/DCWidgetResLayer2D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2D.py
@@ -583,7 +583,7 @@ def plot_Surface_Potentials(
         label = "Current density ($A/m^2$)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)

--- a/geoscilabs/dcip/DCWidgetResLayer2_5D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2_5D.py
@@ -563,7 +563,7 @@ def PLOT(
         label = "Electric Field (V/m)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)
@@ -588,7 +588,7 @@ def PLOT(
         label = "Current density ($A/m^2$)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)

--- a/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
+++ b/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
@@ -565,7 +565,7 @@ def PLOT(
         label = "Electric Field (V/m)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase =False)
@@ -590,7 +590,7 @@ def PLOT(
         label = "Current density ($A/m^2$)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase =False)

--- a/geoscilabs/dcip/DC_cylinder.py
+++ b/geoscilabs/dcip/DC_cylinder.py
@@ -408,7 +408,7 @@ def plot_Surface_Potentials(
         label = "Electric Field (V/m)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)
@@ -433,7 +433,7 @@ def plot_Surface_Potentials(
         label = "Current density ($A/m^2$)"
         xtype = "F"
         view = "vec"
-        streamOpts = {"color": "w"}
+        streamOpts = {"color": "w", "broken_streamlines": False, "density": 0.3}
         ind = indF
 
         # formatter = LogFormatter(10, labelOnlyBase=False)

--- a/notebooks/dcip/DC_Layer_Cylinder_2_5D.ipynb
+++ b/notebooks/dcip/DC_Layer_Cylinder_2_5D.ipynb
@@ -105,9 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ResLayer_app()"
@@ -123,9 +121,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:geosci-labs]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-geosci-labs-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -137,7 +135,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Set `broken_streamlines` to `False` in fields plots. Also set a `density` of 0.3 to avoid having too many lines in the plots. Pin `matplotlib` to `3.6.*`.

Fixes #71 