### PR TITLE
update the notebook used in the lab to use the true 2.5D code

### DIFF
--- a/notebooks/dcip/DC_SurveyDataInversion.ipynb
+++ b/notebooks/dcip/DC_SurveyDataInversion.ipynb
@@ -2,18 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/syckdog/opt/anaconda3/envs/e350_notebook/lib/python3.9/site-packages/discretize/utils/code_utils.py:247: FutureWarning: ExtractCoreMesh has been deprecated, please use extract_core_mesh. It will be removed in version 1.0.0 of discretize.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\")\n",
@@ -21,7 +12,8 @@
     "from geoscilabs.dcip.DCLayers import plot_layer_potentials_app\n",
     "from geoscilabs.dcip.DC_Pseudosections import (\n",
     "    DC2DPseudoWidget, MidpointPseudoSectionWidget, DC2DfwdWidget\n",
-    ")\n"
+    ")\n",
+    "from geoscilabs.dcip.DCWidgetResLayer2_5D import ResLayer_app\n"
    ]
   },
   {
@@ -54,24 +46,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04569e8a845b4a32bc77d043b2950dd3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MyApp(children=(ToggleButtons(description='survey', options=('Dipole-Dipole', 'Dipole-Pole', 'Pole-Dipole', 'P…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cylinder_app()"
    ]
@@ -119,46 +96,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Two layer app"
+    "## Two layer + cylinder app"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- **A**: (+) Current electrode  location\n",
-    "- **B**: (-) Current electrode  location\n",
-    "- **M**: (+) Potential electrode  location\n",
-    "- **N**: (-) Potential electrode  location\n",
-    "- **$\\rho_1$**: Resistivity of the top layer\n",
-    "- **$\\rho_2$**: Resistivity of the bottom layer\n",
-    "- **h**: thickness of the first layer\n",
-    "- **Plot**: Field to visualize\n",
-    "- **Type**: which part of the field"
+    " - **survey**: Type of survey\n",
+    " - **A**: Electrode A (+) location\n",
+    " - **B**: Electrode B (-) location\n",
+    " - **M**: Electrode A (+) location\n",
+    " - **N**: Electrode B (-) location\n",
+    " - **$dz_{layer}$**: thickness of the resistive layer\n",
+    " - **$zc_{ayer}$**: z location of the resistive layer\n",
+    " - **xc**: x location of cylinder center\n",
+    " - **zc**: z location of cylinder center\n",
+    " - **$\\rho_{1}$**: Resistivity of the half-space\n",
+    " - **$\\rho_{2}$**: Resistivity of the layer\n",
+    " - **$\\rho_{3}$**: Resistivity of the cylinder\n",
+    " - **Field**: Field to visualize\n",
+    " - **Type**: which part of the field\n",
+    " - **Scale**: Linear or Log Scale visualization"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d1384e6efce843ca873e1a2f8571cc74",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MyApp(children=(FloatSlider(value=-30.0, continuous_update=False, description='A', max=40.0, min=-40.0, step=1…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "plot_layer_potentials_app()"
+    "ResLayer_app()"
    ]
   },
   {
@@ -198,24 +166,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d645ed44e78b485a93927aa419e818e8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MyApp(children=(IntSlider(value=0, description='i', max=17), Output()), layout=Layout(align_items='stretch', d…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "MidpointPseudoSectionWidget()"
    ]
@@ -242,26 +195,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a25181275ec473a99eb1e64715b50d2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(BoundedFloatText(value=1000.0, description='$\\\\rho_1$', max=1000.0, min=10.0), BoundedFl…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "DC2DPseudoWidget()"
    ]
@@ -296,24 +232,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "79e1c6477a08484db56eb9cd47a1916a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MyApp(children=(BoundedFloatText(value=1000.0, description='$\\\\rho_1$', max=1000.0, min=10.0), BoundedFloatTex…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "DC2DfwdWidget()"
    ]
@@ -343,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.10"
   },
   "widgets": {
    "state": {
@@ -366,5 +287,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This pull request updates the section of the lab notebook that is used for computing apparent resistivities based on the voltages computed to use the 2.5D code, which should give correct results. Note that we could also remove the first part about the cylinder as the 2.5D app that is included can simulate both a layer and the cylinder 