### PR TITLE
update to SimPEG 0.23.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.10", "3.11"]
         test-file: ["tests/test_dcip.py", "tests/test_em.py", "tests/test_gpr.py tests/test_seismic.py", "tests/test_inversion.py", "tests/test_gravity.py tests/test_mag.py"]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10"]
         test-file: ["tests/test_dcip.py", "tests/test_em.py", "tests/test_gpr.py tests/test_seismic.py", "tests/test_inversion.py", "tests/test_gravity.py tests/test_mag.py"]
 
     steps:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - cvxopt
   - deepdish
   - discretize
+  - empymod
   - ipywidgets>=0.6.0
   - jupyter
   - matplotlib=3.4.3

--- a/geoscilabs/dcip/DCIP_overburden_PseudoSection.py
+++ b/geoscilabs/dcip/DCIP_overburden_PseudoSection.py
@@ -25,10 +25,10 @@ import matplotlib.patches as patches
 
 from discretize import TensorMesh
 
-from SimPEG import maps, SolverLU, utils
-from SimPEG.utils import extract_core_mesh
-from SimPEG.electromagnetics.static import resistivity as DC
-from SimPEG.electromagnetics.static import induced_polarization as IP
+from simpeg import maps, SolverLU, utils
+from simpeg.utils import extract_core_mesh
+from simpeg.electromagnetics.static import resistivity as DC
+from simpeg.electromagnetics.static import induced_polarization as IP
 from pymatsolver import Pardiso
 
 from ..base import widgetify

--- a/geoscilabs/dcip/DCIP_overburden_PseudoSection.py
+++ b/geoscilabs/dcip/DCIP_overburden_PseudoSection.py
@@ -29,9 +29,11 @@ from simpeg import maps, SolverLU, utils
 from simpeg.utils import extract_core_mesh
 from simpeg.electromagnetics.static import resistivity as DC
 from simpeg.electromagnetics.static import induced_polarization as IP
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, sigmaMap can be globals global
 npad = 12
@@ -179,13 +181,13 @@ def model_fields(A, B, mtrue, mhalf, mair, mover, whichprimary="overburden"):
         survey = DC.Survey([src])
         # Create three simulations so the fields object is accurate
         sim_primary = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         sim_total = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         sim_air = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
 
         if whichprimary == "air":
@@ -302,7 +304,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     survey = DC.Survey([src])
     problem = DC.Simulation2DCellCentered(
-        mesh, sigmaMap=mapping, solver=Pardiso, survey=survey
+        mesh, sigmaMap=mapping, solver=Solver, survey=survey
     )
 
     J = problem.getJ(model)[0]
@@ -458,7 +460,7 @@ def DC2Dsimulation(mtrue, flag="PoleDipole", nmax=8):
 
     survey = DC.Survey(txList)
     simulation = DC.Simulation2DCellCentered(
-        mesh, sigmaMap=mapping, survey=survey, solver=Pardiso
+        mesh, sigmaMap=mapping, survey=survey, solver=Solver
     )
 
     return simulation, xzlocs
@@ -548,7 +550,7 @@ def IP2Dsimulation(miptrue, sigmadc, flag="PoleDipole", nmax=8):
         sigma=sigmadc,
         etaMap=maps.IdentityMap(mesh),
         survey=survey,
-        solver=Pardiso,
+        solver=Solver,
     )
 
     return simulation, xzlocs

--- a/geoscilabs/dcip/DCLayers.py
+++ b/geoscilabs/dcip/DCLayers.py
@@ -10,9 +10,11 @@ from matplotlib import rcParams
 from discretize import TensorMesh
 
 from simpeg import maps, utils
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 rcParams["font.size"] = 16
 
@@ -172,7 +174,7 @@ def solve_2D_potentials(rho1, rho2, h, A, B):
         * utils.sdiag(1.0 / (mesh.dim * mesh.aveF2CC.T * (1.0 / sigma)))
         * mesh.cell_gradient
     )
-    Ainv = Pardiso(A)
+    Ainv = Solver(A)
 
     V = Ainv * q
     return V

--- a/geoscilabs/dcip/DCLayers.py
+++ b/geoscilabs/dcip/DCLayers.py
@@ -9,7 +9,7 @@ from matplotlib import rcParams
 
 from discretize import TensorMesh
 
-from SimPEG import maps, utils
+from simpeg import maps, utils
 from pymatsolver import Pardiso
 
 from ..base import widgetify
@@ -153,7 +153,7 @@ def rho_a(VM, VN, A, B, M, N):
 
 def solve_2D_potentials(rho1, rho2, h, A, B):
     """
-    Here we solve the 2D DC problem for potentials (using SimPEG Mesg Class)
+    Here we solve the 2D DC problem for potentials (using simpeg Mesg Class)
     """
     sigma = 1.0 / rho2 * np.ones(mesh.nC)
     sigma[mesh.gridCC[:, 1] >= -h] = 1.0 / rho1  # since the model is 2D

--- a/geoscilabs/dcip/DCWidgetPlate2_5D.py
+++ b/geoscilabs/dcip/DCWidgetPlate2_5D.py
@@ -12,13 +12,15 @@ from matplotlib.ticker import LogFormatter
 from matplotlib.path import Path
 import matplotlib.patches as patches
 
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from discretize import TensorMesh
 from simpeg import maps, SolverLU, utils
 from simpeg.utils import extract_core_mesh
 from simpeg.electromagnetics.static import resistivity as DC
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, mapping can be globals global
 npad = 15
@@ -88,10 +90,10 @@ def plate_fields(A, B, dx, dz, xc, zc, rotAng, sigplate, sighalf):
             src = DC.sources.Dipole([], np.r_[A, 0.0], np.r_[B, 0.0])
         survey = DC.survey.Survey([src])
         problem = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         problem_prim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
 
         total_field = problem.fields(mtrue)
@@ -292,7 +294,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     survey = DC.Survey([src])
     sim = DC.Simulation3DCellCentered(
-        mesh, sigmaMap=mapping, solver=Pardiso, survey=survey
+        mesh, sigmaMap=mapping, solver=Solver, survey=survey
     )
     J = sim.getJ(model)[0]
 

--- a/geoscilabs/dcip/DCWidgetPlate2_5D.py
+++ b/geoscilabs/dcip/DCWidgetPlate2_5D.py
@@ -15,9 +15,9 @@ import matplotlib.patches as patches
 from pymatsolver import Pardiso
 
 from discretize import TensorMesh
-from SimPEG import maps, SolverLU, utils
-from SimPEG.utils import extract_core_mesh
-from SimPEG.electromagnetics.static import resistivity as DC
+from simpeg import maps, SolverLU, utils
+from simpeg.utils import extract_core_mesh
+from simpeg.electromagnetics.static import resistivity as DC
 from ..base import widgetify
 
 # Mesh, mapping can be globals global
@@ -272,7 +272,7 @@ def sumPlateCharges(xc, zc, dx, dz, rotAng, qSecondary):
     return qPosSum, qNegSum, qPosAvgLoc, qNegAvgLoc
 
 
-# The only thing we need to make it work is a 2.5D field object in SimPEG
+# The only thing we need to make it work is a 2.5D field object in simpeg
 
 
 def getSensitivity(survey, A, B, M, N, model):

--- a/geoscilabs/dcip/DCWidgetPlate_2D.py
+++ b/geoscilabs/dcip/DCWidgetPlate_2D.py
@@ -14,9 +14,9 @@ import matplotlib.patches as patches
 from pymatsolver import Pardiso
 
 from discretize import TensorMesh
-from SimPEG import maps, SolverLU, utils
-from SimPEG.utils import extract_core_mesh
-from SimPEG.electromagnetics.static import resistivity as DC
+from simpeg import maps, SolverLU, utils
+from simpeg.utils import extract_core_mesh
+from simpeg.electromagnetics.static import resistivity as DC
 
 from ..base import widgetify
 

--- a/geoscilabs/dcip/DCWidgetPlate_2D.py
+++ b/geoscilabs/dcip/DCWidgetPlate_2D.py
@@ -11,7 +11,7 @@ import matplotlib.pylab as pylab
 from matplotlib.ticker import LogFormatter
 from matplotlib.path import Path
 import matplotlib.patches as patches
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from discretize import TensorMesh
 from simpeg import maps, SolverLU, utils
@@ -19,6 +19,8 @@ from simpeg.utils import extract_core_mesh
 from simpeg.electromagnetics.static import resistivity as DC
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, mapping can be globals global
 npad = 15
@@ -91,10 +93,10 @@ def plate_fields(A, B, dx, dz, xc, zc, rotAng, sigplate, sighalf):
         survey = DC.survey.Survey([src])
 
         problem = DC.Simulation3DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         problem_prim = DC.Simulation3DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
 
         primary_field = problem_prim.fields(mhalf)
@@ -293,7 +295,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     survey = DC.Survey([src])
     sim = DC.Simulation3DCellCentered(
-        mesh, sigmaMap=mapping, solver=Pardiso, survey=survey
+        mesh, sigmaMap=mapping, solver=Solver, survey=survey
     )
     J = sim.getJ(model)[0]
 

--- a/geoscilabs/dcip/DCWidgetResLayer2D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2D.py
@@ -11,11 +11,13 @@ from matplotlib.path import Path
 import matplotlib.patches as patches
 from scipy.constants import epsilon_0
 import copy
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from ipywidgets import interact, IntSlider, FloatSlider, FloatText, ToggleButtons
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, sigmaMap can be globals global
 npad = 15
@@ -94,10 +96,10 @@ def model_fields(A, B, zcLayer, dzLayer, xc, zc, r, sigLayer, sigTarget, sigHalf
         survey = DC.Survey([src])
 
         problem = DC.Simulation3DCellCentered(
-            mesh, sigmaMap=sigmaMap, solver=Pardiso, survey=survey
+            mesh, sigmaMap=sigmaMap, solver=Solver, survey=survey
         )
         problem_prim = DC.Simulation3DCellCentered(
-            mesh, sigmaMap=sigmaMap, solver=Pardiso, survey=survey
+            mesh, sigmaMap=sigmaMap, solver=Solver, survey=survey
         )
 
         primary_field = problem_prim.fields(mhalf)
@@ -335,7 +337,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     survey = DC.survey.Survey([src])
     problem = DC.Simulation3DCellCentered(
-        mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso
+        mesh, survey=survey, sigmaMap=sigmaMap, solver=Solver
     )
     J = problem.getJ(model)
 

--- a/geoscilabs/dcip/DCWidgetResLayer2D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2D.py
@@ -1,8 +1,8 @@
 from discretize import TensorMesh
-from SimPEG import maps, SolverLU, utils
-from SimPEG.utils import extract_core_mesh
+from simpeg import maps, SolverLU, utils
+from simpeg.utils import extract_core_mesh
 import numpy as np
-from SimPEG.electromagnetics.static import resistivity as DC
+from simpeg.electromagnetics.static import resistivity as DC
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.pylab as pylab

--- a/geoscilabs/dcip/DCWidgetResLayer2_5D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2_5D.py
@@ -13,13 +13,15 @@ import matplotlib.patches as patches
 from simpeg import maps, SolverLU, utils
 from simpeg.utils import extract_core_mesh
 from simpeg.electromagnetics.static import resistivity as DC
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from discretize import TensorMesh
 
 from ipywidgets import interact, IntSlider, FloatSlider, FloatText, ToggleButtons
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, sigmaMap can be globals global
 npad = 15
@@ -99,11 +101,11 @@ def model_fields(A, B, zcLayer, dzLayer, xc, zc, r, sigLayer, sigTarget, sigHalf
             src = DC.sources.Dipole([], np.r_[A, 0.0], np.r_[B, 0.0])
         survey = DC.Survey([src])
         sim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         total_field = sim.fields(mtrue)
         sim_prim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         primary_field = sim_prim.fields(mhalf)
 
@@ -347,7 +349,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     Src = DC.Survey([src])
     sim = DC.Simulation2DCellCentered(
-        mesh, survey=Src, sigmaMap=mapping, solver=Pardiso
+        mesh, survey=Src, sigmaMap=mapping, solver=Solver
     )
     J = sim.getJ(model)
 

--- a/geoscilabs/dcip/DCWidgetResLayer2_5D.py
+++ b/geoscilabs/dcip/DCWidgetResLayer2_5D.py
@@ -10,9 +10,9 @@ from matplotlib.ticker import LogFormatter
 from matplotlib.path import Path
 import matplotlib.patches as patches
 
-from SimPEG import maps, SolverLU, utils
-from SimPEG.utils import extract_core_mesh
-from SimPEG.electromagnetics.static import resistivity as DC
+from simpeg import maps, SolverLU, utils
+from simpeg.utils import extract_core_mesh
+from simpeg.electromagnetics.static import resistivity as DC
 from pymatsolver import Pardiso
 
 from discretize import TensorMesh
@@ -331,7 +331,7 @@ def sumCylinderCharges(xc, zc, r, qSecondary):
     return qPosSum, qNegSum, qPosAvgLoc, qNegAvgLoc
 
 
-# The only thing we need to make it work is a 2.5D field object in SimPEG
+# The only thing we need to make it work is a 2.5D field object in simpeg
 
 
 def getSensitivity(survey, A, B, M, N, model):

--- a/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
+++ b/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
@@ -21,9 +21,9 @@ from ipywidgets import (
 )
 
 from discretize import TensorMesh
-from SimPEG import maps, utils
-from SimPEG.utils import extract_core_mesh
-from SimPEG.electromagnetics.static import resistivity as DC
+from simpeg import maps, utils
+from simpeg.utils import extract_core_mesh
+from simpeg.electromagnetics.static import resistivity as DC
 
 from pymatsolver import Pardiso
 

--- a/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
+++ b/geoscilabs/dcip/DCWidget_Overburden_2_5D.py
@@ -25,9 +25,11 @@ from simpeg import maps, utils
 from simpeg.utils import extract_core_mesh
 from simpeg.electromagnetics.static import resistivity as DC
 
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, sigmaMap can be globals global
 npad = 12
@@ -165,13 +167,13 @@ def model_fields(A, B, mtrue, mhalf, mair, mover, whichprimary="air"):
             src = DC.sources.Dipole([], np.r_[A, surfaceA], np.r_[B, surfaceB])
         survey = DC.survey.Survey([src])
         problem = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         problem_prim = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
         problem_air = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+            mesh, survey=survey, sigmaMap=mapping, solver=Solver
         )
 
         if whichprimary == "air":
@@ -307,7 +309,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     Src = DC.Survey([src])
     sim = DC.Simulation2DCellCentered(
-        mesh, survey=Src, sigmaMap=mapping, solver=Pardiso
+        mesh, survey=Src, sigmaMap=mapping, solver=Solver
     )
     J = sim.getJ(model)[0]
 

--- a/geoscilabs/dcip/DC_Pseudosections.py
+++ b/geoscilabs/dcip/DC_Pseudosections.py
@@ -18,7 +18,7 @@ from matplotlib.path import Path
 import matplotlib.patches as patches
 
 from discretize import TensorMesh
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
 from simpeg import maps, SolverLU, utils
 from simpeg.electromagnetics.static import resistivity as DC
@@ -27,6 +27,7 @@ from simpeg.electromagnetics.static.utils import static_utils
 
 from ..base import widgetify
 
+Solver = get_default_solver()
 
 class ParametricCircleLayerMap(IdentityMap):
 
@@ -167,7 +168,7 @@ def DC2Dsurvey(flag="PolePole"):
 
     survey = DC.Survey(txList)
     simulation = DC.Simulation2DCellCentered(
-        mesh, survey=survey, sigmaMap=mapping, solver=Pardiso
+        mesh, survey=survey, sigmaMap=mapping, solver=Solver
     )
 
     sigblk, sighalf, siglayer = 2e-2, 2e-3, 1e-3

--- a/geoscilabs/dcip/DC_Pseudosections.py
+++ b/geoscilabs/dcip/DC_Pseudosections.py
@@ -20,10 +20,10 @@ import matplotlib.patches as patches
 from discretize import TensorMesh
 from pymatsolver import Pardiso
 
-from SimPEG import maps, SolverLU, utils
-from SimPEG.electromagnetics.static import resistivity as DC
-from SimPEG.maps import IdentityMap
-from SimPEG.electromagnetics.static.utils import static_utils
+from simpeg import maps, SolverLU, utils
+from simpeg.electromagnetics.static import resistivity as DC
+from simpeg.maps import IdentityMap
+from simpeg.electromagnetics.static.utils import static_utils
 
 from ..base import widgetify
 
@@ -248,7 +248,7 @@ def PseudoSectionPlotfnc(i, j, survey, flag="PoleDipole"):
 
     :param int i: source index
     :param int j: receiver index
-    :param SimPEG.survey survey: SimPEG survey object
+    :param simpeg.survey survey: simpeg survey object
     :param str flag: Survey Type 'PoleDipole', 'DipoleDipole', 'DipolePole'
     """
     matplotlib.rcParams["font.size"] = 14
@@ -436,7 +436,7 @@ def PseudoSectionWidget(survey, flag):
     associated with a particular survey
     for each pair source-receiver
 
-    :param SimPEG.survey survey: Survey object
+    :param simpeg.survey survey: Survey object
     :param str flag: Survey Type 'PoleDipole', 'DipoleDipole', 'DipolePole'
     """
     dx = 5
@@ -496,8 +496,8 @@ def DC2Dfwdfun(
     over a known geological model
 
     :param TensorMesh mesh: discretization of the model
-    :param SimPEG.Simulation sim: simulation object
-    :param SimPEG.SigmaMap mapping: sigmamap of the model
+    :param simpeg.Simulation sim: simulation object
+    :param simpeg.SigmaMap mapping: sigmamap of the model
     :param numpy.array xr: electrodes positions
     :param numpy.array xzlocs: pseudolocations
     :param float rhohalf: Resistivity of the half-space

--- a/geoscilabs/dcip/DC_Pseudosections.py
+++ b/geoscilabs/dcip/DC_Pseudosections.py
@@ -53,7 +53,7 @@ class ParametricCircleLayerMap(IdentityMap):
             sig1, sig2, sig3 = np.exp(sig1), np.exp(sig2), np.exp(sig3)
         sigma = np.ones(mesh.nC) * sig1
         sigma[mesh.gridCC[:, 1] < zh] = sig2
-        blkind = utils.model_builder.getIndicesSphere(np.r_[x, zc], r, mesh.gridCC)
+        blkind = utils.model_builder.get_indices_sphere(np.r_[x, zc], r, mesh.gridCC)
         sigma[blkind] = sig3
         return sigma
 

--- a/geoscilabs/dcip/DC_cylinder.py
+++ b/geoscilabs/dcip/DC_cylinder.py
@@ -7,7 +7,7 @@ from matplotlib.ticker import LogFormatter
 from matplotlib.path import Path
 import matplotlib.patches as patches
 
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 from discretize import TensorMesh
 
 from simpeg import maps, utils
@@ -17,6 +17,8 @@ from simpeg.electromagnetics.static import resistivity as DC
 from ipywidgets import interact, IntSlider, FloatSlider, FloatText, ToggleButtons, BoundedFloatText
 
 from ..base import widgetify
+
+Solver = get_default_solver()
 
 # Mesh, sigmaMap can be globals global
 npad = 15
@@ -88,10 +90,10 @@ def cylinder_fields(A, B, r, sigcyl, sighalf, xc=0.0, zc=-20.0):
 
         # make two simulations for the seperate field objects
         sim_primary = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso
+            mesh, survey=survey, sigmaMap=sigmaMap, solver=Solver
         )
         sim_total = DC.Simulation2DCellCentered(
-            mesh, survey=survey, sigmaMap=sigmaMap, solver=Pardiso
+            mesh, survey=survey, sigmaMap=sigmaMap, solver=Solver
         )
 
         primary_field = sim_primary.fields(mhalf)
@@ -194,7 +196,7 @@ def getSensitivity(survey, A, B, M, N, model):
 
     Src = DC.Survey([src])
     sim = DC.Simulation2DCellCentered(
-        mesh, survey=Src, sigmaMap=sigmaMap, solver=Pardiso
+        mesh, survey=Src, sigmaMap=sigmaMap, solver=Solver
     )
     J = sim.getJ(model)[0]
 

--- a/geoscilabs/dcip/DC_cylinder.py
+++ b/geoscilabs/dcip/DC_cylinder.py
@@ -10,9 +10,9 @@ import matplotlib.patches as patches
 from pymatsolver import Pardiso
 from discretize import TensorMesh
 
-from SimPEG import maps, utils
-from SimPEG.utils import extract_core_mesh, mkvc
-from SimPEG.electromagnetics.static import resistivity as DC
+from simpeg import maps, utils
+from simpeg.utils import extract_core_mesh, mkvc
+from simpeg.electromagnetics.static import resistivity as DC
 
 from ipywidgets import interact, IntSlider, FloatSlider, FloatText, ToggleButtons, BoundedFloatText
 

--- a/geoscilabs/dcip/sphereElectrostatic_example.py
+++ b/geoscilabs/dcip/sphereElectrostatic_example.py
@@ -3,7 +3,7 @@ from scipy.constants import epsilon_0
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 
-from SimPEG.utils import ndgrid, mkvc
+from simpeg.utils import ndgrid, mkvc
 
 """
 Authors: Thibaut Astic, Lindsey Heagy, Sanna Tyrvainen, Ronghua Peng

--- a/geoscilabs/em/BiotSavart.py
+++ b/geoscilabs/em/BiotSavart.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
-from SimPEG import utils
+from simpeg import utils
 from scipy.constants import mu_0
 
 

--- a/geoscilabs/em/DipoleWidget1D.py
+++ b/geoscilabs/em/DipoleWidget1D.py
@@ -1,5 +1,5 @@
 import numpy as np
-from SimPEG import electromagnetics as EM
+from simpeg import electromagnetics as EM
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import matplotlib
@@ -8,7 +8,7 @@ import matplotlib.gridspec as gridspec
 from ipywidgets import ToggleButtons, FloatSlider
 
 from geoscilabs.base import widgetify
-from SimPEG.view import DataView
+from simpeg.view import DataView
 
 matplotlib.rcParams["font.size"] = 12
 

--- a/geoscilabs/em/DipoleWidgetFD.py
+++ b/geoscilabs/em/DipoleWidgetFD.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-# from SimPEG.electromagnetics import frequency_domain as EM
+# from simpeg.electromagnetics import frequency_domain as EM
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import matplotlib

--- a/geoscilabs/em/FDEMDipolarfields.py
+++ b/geoscilabs/em/FDEMDipolarfields.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.constants import mu_0, pi, epsilon_0
 from scipy.special import erf
-from SimPEG import utils
+from simpeg import utils
 
 
 def omega(f):

--- a/geoscilabs/em/FDEMPlanewave.py
+++ b/geoscilabs/em/FDEMPlanewave.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.constants import mu_0, pi, epsilon_0
-from SimPEG import utils
+from simpeg import utils
 
 
 def omega(f):

--- a/geoscilabs/em/HarmonicVMDCylWidget.py
+++ b/geoscilabs/em/HarmonicVMDCylWidget.py
@@ -1,7 +1,7 @@
 from ipywidgets import widgets
 from discretize import CylindricalMesh, TensorMesh
-from SimPEG import maps, utils
-from SimPEG.electromagnetics import frequency_domain as fdem
+from simpeg import maps, utils
+from simpeg.electromagnetics import frequency_domain as fdem
 from pymatsolver import Pardiso
 
 # from pymatsolver import PardisoSolver

--- a/geoscilabs/em/HarmonicVMDCylWidget.py
+++ b/geoscilabs/em/HarmonicVMDCylWidget.py
@@ -2,9 +2,8 @@ from ipywidgets import widgets
 from discretize import CylindricalMesh, TensorMesh
 from simpeg import maps, utils
 from simpeg.electromagnetics import frequency_domain as fdem
-from pymatsolver import Pardiso
+from simpeg.utils.solver_utils import get_default_solver
 
-# from pymatsolver import PardisoSolver
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
@@ -16,6 +15,7 @@ from ..base import widgetify
 from .DipoleWidgetFD import DisPosNegvalues
 from .BiotSavart import BiotSavartFun
 
+Solver = get_default_solver()
 
 class HarmonicVMDCylWidget(object):
     """FDEMCylWidgete"""
@@ -193,7 +193,7 @@ class HarmonicVMDCylWidget(object):
 
         survey = fdem.survey.Survey(self.srcList)
         sim = fdem.Simulation3DMagneticFluxDensity(
-            self.mesh, survey=survey, sigmaMap=self.mapping, mu=self.mu, solver=Pardiso
+            self.mesh, survey=survey, sigmaMap=self.mapping, mu=self.mu, solver=Solver
         )
 
         self.f = sim.fields(self.m)

--- a/geoscilabs/em/Loop.py
+++ b/geoscilabs/em/Loop.py
@@ -10,9 +10,6 @@ from scipy.sparse.linalg import spsolve, splu
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 
-from pymatsolver import Pardiso
-
-
 def rectangular_plane_layout(mesh, corner, closed=False, I=1.0):
     """
     corner: sorted list of four corners (x,y,z)

--- a/geoscilabs/em/PlanewaveWidgetFD.py
+++ b/geoscilabs/em/PlanewaveWidgetFD.py
@@ -1,5 +1,5 @@
 import numpy as np
-from SimPEG.electromagnetics.utils import waveform_utils
+from simpeg.electromagnetics.utils import waveform_utils
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import matplotlib

--- a/geoscilabs/em/TDEMDipolarfields.py
+++ b/geoscilabs/em/TDEMDipolarfields.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.constants import mu_0, pi, epsilon_0
 from scipy.special import erfc, erf
 from discretize.utils import as_array_n_by_dim
-from SimPEG import utils
+from simpeg import utils
 
 # TODO:
 # r = lambda dx, dy, dz: np.sqrt( dx**2. + dy**2. + dz**2.)

--- a/geoscilabs/em/TDEMGroundedSource.py
+++ b/geoscilabs/em/TDEMGroundedSource.py
@@ -88,7 +88,9 @@ def run_simulation(fname="tdem_gs_half.h5", sigma_block=0.01, sigma_halfspace=0.
     from scipy.constants import mu_0
     import numpy as np
     from simpeg import maps, utils
-    from pymatsolver import Pardiso
+    from simpeg.utils.solver_utils import get_default_solver
+
+    Solver = get_default_solver()
 
     cs = 20
     ncx, ncy, ncz = 20, 20, 20
@@ -126,7 +128,7 @@ def run_simulation(fname="tdem_gs_half.h5", sigma_block=0.01, sigma_halfspace=0.
     rxList = [rx_ex, rx_ey, rx_by]
 
     sim = tdem.Simulation3DMagneticFluxDensity(mesh, sigma=sigma, verbose=True)
-    sim.Solver = Pardiso
+    sim.Solver = Solver
     sim.solverOpts = {"is_symmetric": False}
     sim.time_steps = [(1e-3, 10), (2e-5, 10), (1e-4, 10), (5e-4, 10), (1e-3, 10)]
     t0 = 0.01 + 1e-4

--- a/geoscilabs/em/TDEMGroundedSource.py
+++ b/geoscilabs/em/TDEMGroundedSource.py
@@ -3,7 +3,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import deepdish as dd
 from discretize import TensorMesh
-from SimPEG import utils
+from simpeg import utils
 import tarfile
 import os
 
@@ -83,11 +83,11 @@ def choose_model(model):
 
 
 def run_simulation(fname="tdem_gs_half.h5", sigma_block=0.01, sigma_halfspace=0.01):
-    from SimPEG.electromagnetics import time_domain as tdem
-    from SimPEG.electromagnetics.utils import waveform_utils
+    from simpeg.electromagnetics import time_domain as tdem
+    from simpeg.electromagnetics.utils import waveform_utils
     from scipy.constants import mu_0
     import numpy as np
-    from SimPEG import maps, utils
+    from simpeg import maps, utils
     from pymatsolver import Pardiso
 
     cs = 20

--- a/geoscilabs/em/TDEMGroundedSource.py
+++ b/geoscilabs/em/TDEMGroundedSource.py
@@ -100,7 +100,7 @@ def run_simulation(fname="tdem_gs_half.h5", sigma_block=0.01, sigma_halfspace=0.
     hz = [(cs, npad, -1.5), (cs, ncz), (cs, npad, 1.5)]
     mesh = TensorMesh([hx, hy, hz], "CCC")
     sigma = np.ones(mesh.nC) * sigma_halfspace
-    blk_ind = utils.ModelBuilder.getIndicesBlock(
+    blk_ind = utils.ModelBuilder.get_indices_block(
         np.r_[-40, -40, -160], np.r_[40, 40, -80], mesh.gridCC
     )
     sigma[mesh.gridCC[:, 2] > 0.0] = 1e-8

--- a/geoscilabs/em/TDEMGroundedSource.py
+++ b/geoscilabs/em/TDEMGroundedSource.py
@@ -191,7 +191,7 @@ class PlotTDEM(object):
 
     def __init__(self, **kwargs):
         super(PlotTDEM, self).__init__()
-        utils.setKwargs(self, **kwargs)
+        utils.set_kwargs(self, **kwargs)
         self.xmin, self.xmax = self.mesh.cell_centers_x.min(), self.mesh.cell_centers_x.max()
         self.ymin, self.ymax = self.mesh.cell_centers_y.min(), self.mesh.cell_centers_y.max()
         self.zmin, self.zmax = self.mesh.cell_centers_z.min(), self.mesh.cell_centers_z.max()

--- a/geoscilabs/em/TDEMHorizontalLoopCylWidget.py
+++ b/geoscilabs/em/TDEMHorizontalLoopCylWidget.py
@@ -3,7 +3,6 @@ from discretize import TensorMesh, CylindricalMesh
 from simpeg import maps, utils
 from simpeg.electromagnetics import time_domain as tdem
 
-# from pymatsolver import PardisoSolver
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image

--- a/geoscilabs/em/TDEMHorizontalLoopCylWidget.py
+++ b/geoscilabs/em/TDEMHorizontalLoopCylWidget.py
@@ -1,7 +1,7 @@
 from ipywidgets import widgets, FloatText
 from discretize import TensorMesh, CylindricalMesh
-from SimPEG import maps, utils
-from SimPEG.electromagnetics import time_domain as tdem
+from simpeg import maps, utils
+from simpeg.electromagnetics import time_domain as tdem
 
 # from pymatsolver import PardisoSolver
 import matplotlib.pyplot as plt

--- a/geoscilabs/em/TDEMInductiveSource.py
+++ b/geoscilabs/em/TDEMInductiveSource.py
@@ -71,7 +71,9 @@ def run_simulation(fname="tdem_vmd.h5", sigma_halfspace=0.01, src_type="VMD"):
     from scipy.constants import mu_0
     import numpy as np
     from simpeg import maps
-    from pymatsolver import Pardiso
+    from simpeg.utils.solver_utils import get_default_solver
+
+    Solver = get_default_solver()
 
     cs = 20.0
     ncx, ncy, ncz = 5, 3, 4
@@ -118,7 +120,7 @@ def run_simulation(fname="tdem_vmd.h5", sigma_halfspace=0.01, src_type="VMD"):
         sigmaMap=maps.IdentityMap(mesh),
         verbose=True,
         survey=survey,
-        solver=Pardiso,
+        solver=Solver,
     )
     prb.time_steps = [
         (1e-06, 5),

--- a/geoscilabs/em/TDEMInductiveSource.py
+++ b/geoscilabs/em/TDEMInductiveSource.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import deepdish as dd
 from discretize import TensorMesh
-from SimPEG import utils
+from simpeg import utils
 import tarfile
 import os
 
@@ -67,10 +67,10 @@ def choose_source(src_type):
 
 
 def run_simulation(fname="tdem_vmd.h5", sigma_halfspace=0.01, src_type="VMD"):
-    from SimPEG.electromagnetics import time_domain
+    from simpeg.electromagnetics import time_domain
     from scipy.constants import mu_0
     import numpy as np
-    from SimPEG import maps
+    from simpeg import maps
     from pymatsolver import Pardiso
 
     cs = 20.0

--- a/geoscilabs/em/TDEMInductiveSource.py
+++ b/geoscilabs/em/TDEMInductiveSource.py
@@ -180,7 +180,7 @@ class PlotTDEM(object):
 
     def __init__(self, **kwargs):
         super(PlotTDEM, self).__init__()
-        utils.setKwargs(self, **kwargs)
+        utils.set_kwargs(self, **kwargs)
         self.xmin, self.xmax = self.mesh.cell_centers_x.min(), self.mesh.cell_centers_x.max()
         self.ymin, self.ymax = self.mesh.cell_centers_y.min(), self.mesh.cell_centers_y.max()
         self.zmin, self.zmax = self.mesh.cell_centers_z.min(), self.mesh.cell_centers_z.max()

--- a/geoscilabs/em/TDEMPlanewave.py
+++ b/geoscilabs/em/TDEMPlanewave.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.constants import mu_0, pi, epsilon_0
-from SimPEG import utils
+from simpeg import utils
 
 
 def e_field_from_sheet_current(

--- a/geoscilabs/em/UXO_TEM_Widget.py
+++ b/geoscilabs/em/UXO_TEM_Widget.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.sparse import linalg
-from SimPEG import mkvc
+from simpeg import mkvc
 import scipy.optimize as op
 from ..base import widgetify
 from ipywidgets import (

--- a/geoscilabs/inversion/LinearInversionCG.py
+++ b/geoscilabs/inversion/LinearInversionCG.py
@@ -1,14 +1,14 @@
 import numpy as np
 import discretize
-from SimPEG.simulation import LinearSimulation
-from SimPEG.survey import LinearSurvey
-from SimPEG.data import Data
-from SimPEG import data_misfit
-from SimPEG import directives
-from SimPEG import optimization
-from SimPEG import regularization
-from SimPEG import inverse_problem
-from SimPEG import inversion
+from simpeg.simulation import LinearSimulation
+from simpeg.survey import LinearSurvey
+from simpeg.data import Data
+from simpeg import data_misfit
+from simpeg import directives
+from simpeg import optimization
+from simpeg import regularization
+from simpeg import inverse_problem
+from simpeg import inversion
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 

--- a/geoscilabs/inversion/LinearInversionCG.py
+++ b/geoscilabs/inversion/LinearInversionCG.py
@@ -12,7 +12,6 @@ from simpeg import inversion
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
-# from pymatsolver import Pardiso
 import matplotlib
 from ipywidgets import (
     interact,

--- a/geoscilabs/inversion/LinearInversionDirect.py
+++ b/geoscilabs/inversion/LinearInversionDirect.py
@@ -16,7 +16,6 @@ import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import properties
 
-# from pymatsolver import Pardiso
 import matplotlib
 from ipywidgets import (
     interact,

--- a/geoscilabs/inversion/LinearInversionDirect.py
+++ b/geoscilabs/inversion/LinearInversionDirect.py
@@ -1,6 +1,6 @@
 import numpy as np
 from discretize import TensorMesh
-from SimPEG import (
+from simpeg import (
     maps,
     simulation,
     survey,

--- a/geoscilabs/inversion/TomographyInversion.py
+++ b/geoscilabs/inversion/TomographyInversion.py
@@ -130,7 +130,7 @@ class TomographyInversionApp(object):
     def get_block_index(self, xc=50, yc=50, dx=20, dy=20):
         p0 = np.array([xc - dx / 2.0, yc + dy / 2])
         p1 = np.array([xc + dx / 2.0, yc - dy / 2])
-        index = utils.model_builder.getIndicesBlock(p0, p1, self.mesh_prop.gridCC)
+        index = utils.model_builder.get_indices_block(p0, p1, self.mesh_prop.gridCC)
         return index
 
     def get_block_points(self, xc=50, yc=50, dx=20, dy=20):

--- a/geoscilabs/inversion/TomographyInversion.py
+++ b/geoscilabs/inversion/TomographyInversion.py
@@ -16,7 +16,6 @@ from simpeg import (
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
-# from pymatsolver import Pardiso
 import matplotlib
 from ipywidgets import (
     interact,

--- a/geoscilabs/inversion/TomographyInversion.py
+++ b/geoscilabs/inversion/TomographyInversion.py
@@ -1,6 +1,6 @@
 import numpy as np
 from discretize import TensorMesh
-from SimPEG import (
+from simpeg import (
     maps,
     utils,
     simulation,
@@ -28,7 +28,7 @@ from ipywidgets import (
     SelectMultiple,
 )
 import ipywidgets as widgets
-import SimPEG.seismic.straight_ray_tomography as seismic
+import simpeg.seismic.straight_ray_tomography as seismic
 from pylab import hist
 
 

--- a/geoscilabs/mag/Mag.py
+++ b/geoscilabs/mag/Mag.py
@@ -2,8 +2,8 @@ from . import MagUtils
 from scipy.constants import mu_0
 import re
 import numpy as np
-from SimPEG import utils, data
-from SimPEG.potential_fields import magnetics as mag
+from simpeg import utils, data
+from simpeg.potential_fields import magnetics as mag
 
 
 class Simulation(object):
@@ -316,7 +316,7 @@ def Intrgl_Fwr_Op(xn, yn, zn, rxLoc):
 
 def createMagSurvey(xyzd, B):
     """
-        Create SimPEG magnetic survey pbject
+        Create simpeg magnetic survey pbject
 
         INPUT
         :param array: xyzd, n-by-4 array of observation points and data

--- a/geoscilabs/mag/MagDipoleApp.py
+++ b/geoscilabs/mag/MagDipoleApp.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 from discretize import TensorMesh
 from discretize.utils import closest_points_index
-from SimPEG import utils
+from simpeg import utils
 from geoana import em
 from ipywidgets import widgets
 from ipywidgets import Layout
@@ -222,7 +222,7 @@ class MagneticDipoleApp(object):
         fit_model=False
     ):
         self.component = component
-        self.inclination = -inclination  # -ve accounts for LH modeling in SimPEG
+        self.inclination = -inclination  # -ve accounts for LH modeling in simpeg
         self.declination = declination
         self.length = length
         self.dx = dx
@@ -253,7 +253,7 @@ class MagneticDipoleApp(object):
         z = np.r_[1.0]
         B = np.r_[
             B0, -inclination, declination
-        ]  # -ve accounts for LH modeling in SimPEG
+        ]  # -ve accounts for LH modeling in simpeg
 
         # Project to the direction  of earth field
         if component == "Bt":

--- a/geoscilabs/mag/Simulator.py
+++ b/geoscilabs/mag/Simulator.py
@@ -769,13 +769,7 @@ def fitline(prism, survey, dobj):
             value=53500
         ),
         depth=widgets.FloatSlider(min=0.0, max=5.0, step=0.05, value=0.5),
-        susc=widgets.FloatSlider(
-            min=0.0,
-            max=1.0,
-            step=0.001,
-            value=0.0,
-            readout_format=".2e",
-        ),
+        susc=widgets.FloatSlider(min=0.0, max=800.0, step=5.0, value=1.0),
         comp=widgets.ToggleButtons(options=["tf", "bx", "by", "bz"]),
         irt=widgets.ToggleButtons(options=["induced", "remanent", "total"]),
         Q=widgets.FloatSlider(min=0.0, max=10.0, step=0.1, value=0.0),

--- a/geoscilabs/mag/Simulator.py
+++ b/geoscilabs/mag/Simulator.py
@@ -9,8 +9,8 @@ from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from scipy.interpolate import griddata, interp1d
 
-from SimPEG.potential_fields import magnetics as mag
-from SimPEG import utils, data
+from simpeg.potential_fields import magnetics as mag
+from simpeg import utils, data
 from scipy.constants import mu_0
 
 

--- a/geoscilabs/seismic/NMOwidget.py
+++ b/geoscilabs/seismic/NMOwidget.py
@@ -1,6 +1,6 @@
 from IPython.display import set_matplotlib_formats
 import matplotlib
-from SimPEG.utils import download, mkvc, sub2ind
+from simpeg.utils import download, mkvc, sub2ind
 import numpy as np
 import scipy.io
 from ipywidgets import (


### PR DESCRIPTION
- change imports from `SimPEG` to `simpeg`
- update dev environment to use SimPEG 0.23.0
- use default solver rather than Pardiso
- update calls to model builder code
- drop testing with python 3.8